### PR TITLE
Bump supported version to 1.3

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@ pub struct Ffa;
 
 impl Ffa {
     const FFA_VERSION_MAJOR: u64 = 1;
-    const FFA_VERSION_MINOR: u64 = 0;
+    const FFA_VERSION_MINOR: u64 = 3;
 
     pub fn new() -> Self {
         Ffa {}


### PR DESCRIPTION
Latest FFA release is 1.3. Our goal is to support the latest release, so we're bumping our minor version to match.