### PR TITLE
Remove defmt from the project

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,6 @@ keywords = [ "no_std", "embedded" ]
 categories = [ "embedded", "no-std" ]
 rust-version = "1.75"
 
-[dependencies]
-defmt = { version = "0.3.8", optional = true }
-
-[features]
-defmt = ["dep:defmt"]
-
 [package.metadata.docs.rs]
 targets = [
     "aarch64-unknown-none",

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -7,7 +7,6 @@ macro_rules! ffa_version {
 }
 
 #[derive(Default)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct FfaVersion {
     _major: u16,
     _minor: u16,


### PR DESCRIPTION
Sadly, defmt targets thumbv6/7/8 only. It wouldn't be useful for aarch64, at least not yet. For now, remove defmt from the project.

Closes #16 