### PR TITLE
permit building with stable rust

### DIFF
--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -88,6 +88,7 @@ macro_rules! print {
 macro_rules! println {
     () => ($crate::print!("\n"));
     ($($arg:tt)*) => ({
-        $crate::console::_print(format_args_nl!($($arg)*));
+        $crate::console::_print(format_args!($($arg)*));
+        $crate::console::_print(format_args!("\n"))
     })
 }


### PR DESCRIPTION
Remove the `format_args_nl` call so the library can be built with stable rust