### PR TITLE
Update UUID format to match OS 26390 and later

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@
 use console::FfaConsole;
 use features::FfaFeatures;
 use msg::FfaMsg;
-use uuid::Uuid;
 use version::FfaVersion;
 
 #[macro_use]
@@ -21,27 +20,6 @@ pub mod version;
 pub mod yld;
 
 pub type Result<T> = core::result::Result<T, FfaError>;
-
-pub fn u64_to_uuid(high: u64, low: u64) -> Uuid {
-    let mut bytes = [0u8; 16];
-    bytes[..4].copy_from_slice(&high.to_be_bytes()[4..]);
-    bytes[4..8].copy_from_slice(&high.to_be_bytes()[..4]);
-    bytes[8..12].copy_from_slice(&low.to_be_bytes()[4..]);
-    bytes[12..].copy_from_slice(&low.to_be_bytes()[..4]);
-    Uuid::from_bytes(bytes)
-}
-
-fn uuid_to_u64(uuid: Uuid) -> (u64, u64) {
-    let bytes = uuid.as_bytes();
-    let hl = u32::from_be_bytes(bytes[..4].try_into().unwrap());
-    let hh = u32::from_be_bytes(bytes[4..8].try_into().unwrap());
-    let ll = u32::from_be_bytes(bytes[8..12].try_into().unwrap());
-    let lh = u32::from_be_bytes(bytes[12..16].try_into().unwrap());
-    (
-        (hh as u64) << 32 | (hl as u64),
-        (lh as u64) << 32 | (ll as u64),
-    )
-}
 
 #[derive(PartialOrd, Ord, PartialEq, Eq, Debug)]
 pub enum FfaError {

--- a/src/msg/mod.rs
+++ b/src/msg/mod.rs
@@ -3,16 +3,15 @@ use core::{mem, slice};
 use uuid::Uuid;
 
 use super::{ffa_smc, FfaError, FfaFunctionId, FfaParams, Result};
-use crate::{u64_to_uuid, uuid_to_u64};
 
 impl From<&FfaMsg> for FfaParams {
     fn from(msg: &FfaMsg) -> Self {
-        let (uuid_high, uuid_low) = uuid_to_u64(msg.uuid);
+        let (uuid_high, uuid_low) = msg.uuid.as_u64_pair();
         FfaParams {
             x0: msg.function_id,
             x1: ((msg.source_id as u64) << 16) | (msg.destination_id as u64),
-            x2: uuid_high,
-            x3: uuid_low,
+            x2: uuid_high.to_be(),
+            x3: uuid_low.to_be(),
             x4: msg.args64[0],
             x5: msg.args64[1],
             x6: msg.args64[2],
@@ -37,7 +36,7 @@ impl From<FfaParams> for FfaMsg {
             function_id: params.x0,              // Function id is in lower 32 bits of x0
             source_id: (params.x1 >> 16) as u16, // Source in upper 16 bits
             destination_id: params.x1 as u16,    // Destination in lower 16 bits
-            uuid: u64_to_uuid(params.x2, params.x3),
+            uuid: Uuid::from_u64_pair(params.x2.to_be(), params.x3.to_be()),
             args64: [
                 params.x4, params.x5, params.x6, params.x7, params.x8, params.x9, params.x10,
                 params.x11, params.x12, params.x13, params.x14, params.x15, params.x16, params.x17,


### PR DESCRIPTION
New OS drops changed the format of the UUID in x2 and x3 to match ARM FFA requirements and now it is normal to decode.

x2 contains u64 high bits in LE format
x3 contains u64 low bits in LE format

Note with this change for QEMU and Minos need to use OS 26390 or later. 