### PR TITLE
Fallible to/from FfaFunctionId

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ impl FfaError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FfaFunctionId {
     FfaError,
     FfaSuccess64,
@@ -157,9 +157,11 @@ impl From<FfaFunctionId> for u64 {
     }
 }
 
-impl From<u64> for FfaFunctionId {
-    fn from(value: u64) -> FfaFunctionId {
-        match value {
+impl TryFrom<u64> for FfaFunctionId {
+    type Error = ();
+
+    fn try_from(value: u64) -> core::result::Result<Self, Self::Error> {
+        Ok(match value {
             0x84000060 => FfaFunctionId::FfaError,
             0x84000061 => FfaFunctionId::FfaSuccess32,
             0xc4000061 => FfaFunctionId::FfaSuccess64,
@@ -194,8 +196,8 @@ impl From<u64> for FfaFunctionId {
             0xc400008a => FfaFunctionId::FfaConsoleLog,
             0xc400008d => FfaFunctionId::FfaMsgSendDirectReq2,
             0xc400008e => FfaFunctionId::FfaMsgSendDirectResp2,
-            _ => panic!("Unknown FfaFunctionId value"),
-        }
+            _ => return Err(()),
+        })
     }
 }
 
@@ -222,7 +224,10 @@ impl Ffa {
     pub fn msg_wait(&self) -> Result<FfaMsg> {
         let msg = FfaMsg {
             function_id: FfaFunctionId::FfaMsgWait.into(),
-            ..Default::default()
+            source_id: Default::default(),
+            destination_id: Default::default(),
+            uuid: Default::default(),
+            args64: Default::default(),
         };
         msg.exec()
     }

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1,3 +1,5 @@
+use crate::FfaError;
+
 use super::{ffa_smc, FfaFunctionId, FfaParams, Result};
 
 impl From<&FfaMemory> for FfaParams {
@@ -32,10 +34,10 @@ impl FfaMemory {
     fn exec(&self) -> Result<FfaParams> {
         let params: FfaParams = self.into();
         let result = ffa_smc(params);
-
         let err = result.x2 as i64;
+        let function_id = FfaFunctionId::try_from(result.x0).map_err(|_| FfaError::UnknownError)?;
 
-        match FfaFunctionId::from(result.x0) {
+        match function_id {
             FfaFunctionId::FfaSuccess32 | FfaFunctionId::FfaMemRetrieveResp => Ok(result),
             FfaFunctionId::FfaError => Err(err.into()),
             _ => panic!("Unknown error"),

--- a/src/notify/mod.rs
+++ b/src/notify/mod.rs
@@ -63,9 +63,9 @@ impl FfaNotify {
         let params: FfaParams = self.into();
 
         let result = ffa_smc(params);
-        let id = FfaFunctionId::from(result.x0);
+        let function_id = FfaFunctionId::try_from(result.x0).map_err(|_| FfaError::UnknownError)?;
 
-        match id {
+        match function_id {
             FfaFunctionId::FfaSuccess32 => Ok(result.into()),
             FfaFunctionId::FfaError => Err(FfaError::InvalidParameters),
             _ => panic!("Unknown FfaFunctionId"),

--- a/src/rxtx/mod.rs
+++ b/src/rxtx/mod.rs
@@ -32,7 +32,7 @@ impl FfaRxTxMsg {
 
         let err = result.x2 as i64;
 
-        match FfaFunctionId::from(result.x0) {
+        match FfaFunctionId::try_from(result.x0).unwrap() {
             FfaFunctionId::FfaSuccess32 => FfaError::Ok,
             FfaFunctionId::FfaError => err.into(),
             _ => panic!("Unknown error"),

--- a/src/yld/mod.rs
+++ b/src/yld/mod.rs
@@ -1,8 +1,7 @@
 use super::{ffa_smc, FfaError, FfaFunctionId, FfaParams};
 
-#[derive(Default)]
 pub struct FfaYield {
-    pub function_id: u64,
+    pub function_id: FfaFunctionId,
     pub vcpu_id: u16,
     pub endpoint_id: u16,
     pub timeout_lo: u32,
@@ -37,7 +36,7 @@ impl FfaYield {
 
         let result = ffa_smc(params);
 
-        match result.x0.into() {
+        match result.x0.try_into().unwrap() {
             FfaFunctionId::FfaSuccess32 => FfaError::Ok,
             FfaFunctionId::FfaError => (result.x2 as i64).into(),
             _ => {


### PR DESCRIPTION
Allow conversions to/from `FfaFunctionId` to be fallible. Higher levels can then handle invalid function codes.